### PR TITLE
Add db-types package to fix ModuleNotFoundError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 streamlit
+db-types
 google-auth
 google-cloud-storage
 google-cloud
 google-cloud-bigquery
 pandas
 datetime
-click==8


### PR DESCRIPTION
## 📚  Context
The app throws a `ValueError` due to an underlying `ModuleNotFoundError` for the missing `db-types` package.

![image](https://user-images.githubusercontent.com/20672874/168214145-df5904b3-9455-4fe8-87e9-fd1e0d24fa0a.png)

## 🧠  Description of Changes
- Adds `db-types` to requirements.txt
- Removes click from requirements as the dependency issue was fixed in Streamlit v1.8.1+
