### PR TITLE
Fix type bug in date column causing a axis label render issue

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,8 @@ def monthly_downloads(start_date):
 
     # Percentage difference (between 0-1) of downloads of current vs previous month
     df["delta"] = (df.groupby(["project"])["downloads"].pct_change()).fillna(0)
+    # BigQuery returns the date column as type dbdate, which is not supported by Altair/Vegalite
+    df["date"] = df["date"].astype("datetime64")
 
     return df
 
@@ -74,6 +76,8 @@ def weekly_downloads(start_date):
     )
     # Percentage difference (between 0-1) of downloads of current vs previous month
     df["delta"] = (df.groupby(["project"])["downloads"].pct_change()).fillna(0)
+    # BigQuery returns the date column as type dbdate, which is not supported by Altair/Vegalite
+    df["date"] = df["date"].astype("datetime64")
 
     return df
 


### PR DESCRIPTION
## 📚  Context
IIUC the latest release of [google-cloud-bigquery](https://pypi.org/project/google-cloud-bigquery/3.0.1/#history) when returning a pandas dataframe from BigQuery, returns the type of a column with dates as `dbdate` instead of `datetime64`, like it previously used to.

Altair/vegalite does not support this type and causes the date in x-axis labels and tooltips to be rendered incorrectly. The solution is to explicitly set the type of date columns to `datetime64`.

### _Revised_
![image](https://user-images.githubusercontent.com/20672874/168526980-4a14f0aa-c721-4273-b37e-076ffc9c471d.png)

### _Current_
![image](https://user-images.githubusercontent.com/20672874/168527158-82a37126-6736-4bf7-a1f8-c07aada0402c.png)

