### PR TITLE
Only show downloads for completed weeks

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,6 +71,7 @@ def weekly_downloads(start_date):
         WHERE date >= '{start_date}'
             AND project IN ('pandas', 'keras', 'torch', 'tensorflow', 'numpy', 'sci-kit learn')
         GROUP BY 1,2
+        HAVING date_diff(CURRENT_DATE(), max(date_trunc(date, WEEK)), DAY) >=7
         ORDER BY 1,2 ASC
         """,
     )


### PR DESCRIPTION
When filtering by week, we aggregate downloads from Sunday to Sunday. If you view the graph for the most recent week, and you're viewing it on a day other than Sunday `i.e. 86% of the time`, the number of downloads don't account for an entire 7-day period. 

As a result, it almost always looks like there's a drop in downloads for the current week; when in fact it hasn't been 7 days since the start of the week.

This PR makes it so that we only show downloads for completed weeks. i.e. where 7 days have passed between the start of the week and when you're viewing the app.